### PR TITLE
Add education details to additional info section, and styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,6 +156,34 @@
                     <p class="additional-info__education-university-name">
                       Binary Studio Academy
                     </p>
+
+                    <span
+                      class="additional-info__education-university-durability"
+                    >
+                      2016-2018, New York, United States
+                    </span>
+                    <h3
+                      class="additional-info__education-university-speciality"
+                    >
+                      Sports Management
+                    </h3>
+                    <p class="additional-info__education-university-name">
+                      Columbia University
+                    </p>
+
+                    <span
+                      class="additional-info__education-university-durability"
+                    >
+                      2010-2014, Bandung, Indonesia
+                    </span>
+                    <h3
+                      class="additional-info__education-university-speciality"
+                    >
+                      Economics
+                    </h3>
+                    <p class="additional-info__education-university-name">
+                      Padjadjaran University
+                    </p>
                   </div>
                 </div>
 

--- a/styles.css
+++ b/styles.css
@@ -258,3 +258,12 @@ body {
 .additional-info__languages-item {
   color: var(--secondary-text-color);
 }
+
+.additional-info__education-university-speciality {
+  margin-top: -0.5rem;
+  margin-bottom: -0.5rem;
+}
+
+.additional-info__education-university-name {
+  margin-bottom: 1rem;
+}


### PR DESCRIPTION
This PR updates the feature/body branch by merging educational background details from patch/content/education. Changes include:

 Added education block under the .additional-info section.

Included university name, year of study, and field of study.

This continues to build out the secondary content section of the resume.

